### PR TITLE
Update Ex4 to use the existing OCP 4 bastion to verify the migration.

### DIFF
--- a/mtc/bookbag/workshop/content/Hooks.adoc
+++ b/mtc/bookbag/workshop/content/Hooks.adoc
@@ -50,7 +50,7 @@ Now we are displayed the OCS3/Gluster persistent volume associated with our appl
 
 image:./screenshots/lab8/mtc-migplan-pvs.png[MTC Mig Plan PVs]
 
-Next, we will need to select the `copy method` and `target storage class`. MTC will attempt to pre-select these for you as defaults. In our case, we want *Filesystem copy* and *ocs-storagecluster-cephfs*. Click Next.
+Next, we will need to select the `copy method` and `target storage class`. MTC will attempt to pre-select these for you as defaults. In our case, we want *Filesystem copy* and *ocs-storagecluster-ceph-rbd*. Click Next.
 
 image:./screenshots/lab8/mtc-migplan-copyoptions.png[MTC Mig Plan CopyOptions]
 

--- a/mtc/bookbag/workshop/content/exercises/Ex4.adoc
+++ b/mtc/bookbag/workshop/content/exercises/Ex4.adoc
@@ -371,11 +371,12 @@ You can continuously describe the MigMigration to see phase info, or tail the mi
 
 === Verification
 
-Let’s `oc login` to our OCP 4 cluster from the OCP 3 bastion host and run the `probe.sh` script to verify that the applications have been migrated and are running:
+From the OCP 4 cluster, set the necessary environment variable used by the `probe.sh` script and execute this script to verify that the applications have been migrated and are running:
 
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
-$ **./probe.sh 5**
+$ **echo 5 > .ns**
+$ **./probe.sh**
 Probing app in namespace hello-openshift-1
 Hello OpenShift!
 Probing app in namespace hello-openshift-2

--- a/mtc/bookbag/workshop/content/exercises/Ex4.adoc
+++ b/mtc/bookbag/workshop/content/exercises/Ex4.adoc
@@ -371,12 +371,11 @@ You can continuously describe the MigMigration to see phase info, or tail the mi
 
 === Verification
 
-From the OCP 4 cluster, set the necessary environment variable used by the `probe.sh` script and execute this script to verify that the applications have been migrated and are running:
+From the OCP 4 cluster, run the `probe.sh` script and provide it with the number of applications that were deployed for the migration.
 
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
-$ **echo 5 > .ns**
-$ **./probe.sh**
+$ **./probe.sh 5**
 Probing app in namespace hello-openshift-1
 Hello OpenShift!
 Probing app in namespace hello-openshift-2


### PR DESCRIPTION
During the prerequisites, users create two terminal windows: one to connect to the OCP 3 bastion and one to connect to the OCP 4 bastion. They log in to the the OCP clusters from the respective bastion. I suggest to not log in to the OCP 4 cluster from the OCP 3 bastion as this might be confusing and they will have to switch to the OCP 3 cluster again for the following exercises and the script is also available on the OCP 4 bastion. Also, the argument in "./probe.sh 5" is not used by the script.