### PR TITLE
remove excess GUIDs

### DIFF
--- a/mtc/bookbag/workshop/content/Environment.adoc
+++ b/mtc/bookbag/workshop/content/Environment.adoc
@@ -24,9 +24,9 @@ image::screenshots/lab1/labenv-overview.png[Lab Environment Overview, width=50%,
 |===
 |Key |Value
 |GUID | {OCP3_GUID}
-|OCP Console |https://master.{OCP3_GUID}.{OCP3_DOMAIN}/console
+|OCP Console |https://master.{OCP3_DOMAIN}/console
 |Password |{OCP3_PASSWORD}
-|API |https://master.{OCP3_GUID}.{OCP3_DOMAIN}
+|API |https://master.{OCP3_DOMAIN}
 |Bastion Host |{OCP3_BASTION}
 |Bastion SSH user/password |{OCP3_SSH_USER}/{OCP3_PASSWORD}
 |===
@@ -37,9 +37,9 @@ image::screenshots/lab1/labenv-overview.png[Lab Environment Overview, width=50%,
 |===
 |Key |Value
 |GUID | {OCP4_GUID}
-|OCP Console |http://console-openshift-console.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+|OCP Console |http://console-openshift-console.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 |Password |{OCP4_PASSWORD}
-|API |https://api.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}:6443
+|API |https://api.cluster-{OCP4_GUID}.{OCP4_DOMAIN}:6443
 |Bastion Host |{OCP4_BASTION}
 |Bastion SSH user/password |{OCP4_SSH_USER}/{OCP4_PASSWORD}
 |===

--- a/mtc/bookbag/workshop/content/Environment.adoc
+++ b/mtc/bookbag/workshop/content/Environment.adoc
@@ -27,6 +27,7 @@ image::screenshots/lab1/labenv-overview.png[Lab Environment Overview, width=50%,
 |OCP Console |https://master.{OCP3_DOMAIN}/console
 |Password |{OCP3_PASSWORD}
 |API |https://master.{OCP3_DOMAIN}
+|OCP admin user/password| admin/{OCP3_PASSWORD}
 |Bastion Host |{OCP3_BASTION}
 |Bastion SSH user/password |{OCP3_SSH_USER}/{OCP3_PASSWORD}
 |===

--- a/mtc/bookbag/workshop/content/Hooks.adoc
+++ b/mtc/bookbag/workshop/content/Hooks.adoc
@@ -306,7 +306,7 @@ Once the migration has completed, let's verify that MediaWiki has been migrated 
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
 $ **oc get route mediawiki -n mediawiki -o jsonpath='{.spec.host}{"\n"}'**
-mediawiki-mediawiki.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+mediawiki-mediawiki.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 --------------------------------------------------------------------------------
 
 image:./screenshots/lab8/mediawiki.png[MediaWiki]

--- a/mtc/bookbag/workshop/content/Overview.adoc
+++ b/mtc/bookbag/workshop/content/Overview.adoc
@@ -84,11 +84,11 @@ We should already have MTC UI opened from the previous steps. In case you don't 
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
 $ **oc get routes migration -n openshift-migration -o jsonpath='{.spec.host}{"\n"}'**
-migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 --------------------------------------------------------------------------------
 
 Next, open a browser to the route from above.  +
-https://migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+https://migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 
 image:./screenshots/lab2/mtcUI.png[MTC Main Screen]
 

--- a/mtc/bookbag/workshop/content/Prereqs.adoc
+++ b/mtc/bookbag/workshop/content/Prereqs.adoc
@@ -42,8 +42,13 @@ In that window, let's go ahead and ssh into the bastion host, and then login int
 $ **ssh {OCP3_SSH_USER}@{OCP3_BASTION}**
 {OCP3_SSH_USER}@{OCP3_BASTION}'s password:
 Last login: Sun Mar 22 21:22:55 2020 from 66.26.68.90
-[{OCP3_SSH_USER}@master1 0 ~]$
+[{OCP3_SSH_USER}@bastion 0 ~]$
+--------------------------------------------------------------------------------
 
+Run `oc login` command to log into your OCP3 cluster from the terminal:
+
+[source,bash,subs="{markup-in-source}"]
+--------------------------------------------------------------------------------
 $ **oc login https://master.{OCP3_DOMAIN} -u admin -p {OCP3_PASSWORD}**
 The server uses a certificate signed by an unknown authority.
 You can bypass the certificate check, but any data you send to the server could be intercepted by others.

--- a/mtc/bookbag/workshop/content/Prereqs.adoc
+++ b/mtc/bookbag/workshop/content/Prereqs.adoc
@@ -44,7 +44,7 @@ $ **ssh {OCP3_SSH_USER}@{OCP3_BASTION}**
 Last login: Sun Mar 22 21:22:55 2020 from 66.26.68.90
 [{OCP3_SSH_USER}@master1 0 ~]$
 
-$ **oc login https://master.{OCP3_GUID}.{OCP3_DOMAIN} -u admin -p {OCP3_PASSWORD}**
+$ **oc login https://master.{OCP3_DOMAIN} -u admin -p {OCP3_PASSWORD}**
 The server uses a certificate signed by an unknown authority.
 You can bypass the certificate check, but any data you send to the server could be intercepted by others.
 Use insecure connections? (y/n): y
@@ -67,7 +67,7 @@ Run `oc login` command to log into your OCP4 cluster from the terminal:
 
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
-$ **oc login https://api.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}:6443 -u admin -p {OCP4_PASSWORD}**
+$ **oc login https://api.cluster-{OCP4_GUID}.{OCP4_DOMAIN}:6443 -u admin -p {OCP4_PASSWORD}**
 Login successful.
 
 You have access to 65 projects, the list has been suppressed. You can list all projects with 'oc projects'
@@ -125,13 +125,13 @@ velero-5bffbd77c4-xcbns                 1/1     Running   0          5m11s
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
 $ **oc get routes migration -n openshift-migration -o jsonpath='{.spec.host}{"\n"}'**
-migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 --------------------------------------------------------------------------------
 
 [start=2]
 . For this example we’d visit the below from our browser. Please accept any self-signed certificates:
 
-* https://migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+* https://migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 
 ==== Accept API Certificates on Source and Destination Clusters
 
@@ -139,11 +139,11 @@ migration-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
 
 * Visit the links displayed by the Web UI. If there is a pop-up requesting "Refresh" just cancel it, and follow the hyperlinks. Here are the links you will need to follow:
 ** OCP4:
-*** OCP 4.x: https://api.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}:6443/.well-known/oauth-authorization-server
-*** OCP 4.x: https://discovery-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}/namespaces/openshift-migration/clusters/host/namespaces 
+*** OCP 4.x: https://api.cluster-{OCP4_GUID}.{OCP4_DOMAIN}:6443/.well-known/oauth-authorization-server
+*** OCP 4.x: https://discovery-openshift-migration.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}/namespaces/openshift-migration/clusters/host/namespaces 
 ** OCP3:
-*** OCP 3.x: https://master.{OCP3_GUID}.{OCP3_DOMAIN}/.well-known/oauth-authorization-server
-*** OCP 3.x: https://master.{OCP3_GUID}.{OCP3_DOMAIN}/api/v1/namespaces
+*** OCP 3.x: https://master.{OCP3_DOMAIN}/.well-known/oauth-authorization-server
+*** OCP 3.x: https://master.{OCP3_DOMAIN}/api/v1/namespaces
 * After accepting the API certs, reload the MTC UI URL.
 * Get redirected to login page.
 
@@ -186,7 +186,7 @@ s3     LoadBalancer   172.30.209.151   ab6e67b04f2fc4ad1bb126ad89db0962-17967254
 [source,subs="{markup-in-source}"]
 --------------------------------------------------------------------------------
 $ **oc get routes noobaa-mgmt -n openshift-storage -o jsonpath='{.spec.host}{"\n"}'**
-noobaa-mgmt-openshift-storage.apps.cluster-{OCP4_GUID}.{OCP4_GUID}.{OCP4_DOMAIN}
+noobaa-mgmt-openshift-storage.apps.cluster-{OCP4_GUID}.{OCP4_DOMAIN}
 --------------------------------------------------------------------------------
 
 After giving your credentials, noobaa service account will ask for permission to access your admin account.


### PR DESCRIPTION
For GPTE BEUI (babylon Event UI) we don't need the extra GUIDs in the domain names of the OpenShift servers.